### PR TITLE
Use $attributes as documented within Laravel docs

### DIFF
--- a/views/field.blade.php
+++ b/views/field.blade.php
@@ -3,6 +3,6 @@
         <div class="tinymce border p-3" id="tinymce-wrapper-{{$id}}" style="min-height: {{ $attributes['height'] }}">
             {!! $value !!}
         </div>
-        <input type="hidden" @attributes($attributes)>
+        <input type="hidden" {{ $attributes }}>
     </div>
 @endcomponent


### PR DESCRIPTION
For some reason `@attributes` is not working on some environments.
Lets use `{{$attributes}}` as it's documented within https://laravel.com/docs/8.x/blade#managing-attributes